### PR TITLE
Restore original pg_bitemporal files and comment out transactions

### DIFF
--- a/sql/_load_all.sql
+++ b/sql/_load_all.sql
@@ -8,7 +8,7 @@ set client_min_messages to warning;
 \ir extensions.sql
 \ir relationships.sql
 
-begin;
+--begin;
 set search_path to bitemporal_internal, public;
 
 
@@ -29,5 +29,5 @@ set search_path to bitemporal_internal, public;
 \ir ll_bitemporal_update_select.sql
 \ir ll_bitemporal_delete_select.sql
 
-commit;
+--commit;
 

--- a/sql/extensions.sql
+++ b/sql/extensions.sql
@@ -1,7 +1,7 @@
-begin;
+--begin;
 set local search_path to public;
 
 create extension if not exists btree_gist;
 
 
-commit;
+--commit;

--- a/sql/relationships.sql
+++ b/sql/relationships.sql
@@ -1,4 +1,4 @@
-begin;
+--begin;
 create schema if not exists temporal_relationships;
 grant usage on schema temporal_relationships to public;
 set local search_path to temporal_relationships, public;
@@ -337,6 +337,6 @@ as $$
    select fst(a) >= snd(b) or fst(b) >= snd(a) ;
 $$
 SET search_path = 'temporal_relationships';
-commit;
+--commit;
 
 -- vim: set filetype=pgsql expandtab tabstop=2 shiftwidth=2:


### PR DESCRIPTION
pgFormatter's formatting was breaking many things. Since we're not running tests, there's no way to know what's broken. 
It's best to leave them unformatted for now.