### PR TITLE
Bug fix in bitemporal update

### DIFF
--- a/sql/_load_all.sql
+++ b/sql/_load_all.sql
@@ -8,7 +8,7 @@ set local client_min_messages to warning;
 \ir extensions.sql
 \ir relationships.sql
 
--- begin;
+ begin;
 set local search_path to bitemporal_internal, public;
 
 
@@ -29,5 +29,5 @@ set local search_path to bitemporal_internal, public;
 \ir ll_bitemporal_update_select.sql
 \ir ll_bitemporal_delete_select.sql
 
--- commit;
+ commit;
 

--- a/sql/extensions.sql
+++ b/sql/extensions.sql
@@ -1,7 +1,7 @@
--- begin;
+ begin;
 set local search_path to public;
 
 create extension if not exists btree_gist;
 
 
--- commit;
+ commit;

--- a/sql/ll_bitemporal_list_of_fields.sql
+++ b/sql/ll_bitemporal_list_of_fields.sql
@@ -31,18 +31,28 @@ CREATE OR REPLACE FUNCTION bitemporal_internal.ll_bitemporal_list_of_fields(p_ta
 AS
 $BODY$
 BEGIN
-RETURN ( array(SELECT attname
+RETURN ( array (SELECT attname
                           FROM (SELECT * FROM pg_attribute
                                   WHERE attrelid=p_table::regclass AND attnum >0) pa
                           LEFT OUTER JOIN pg_attrdef pad ON adrelid=p_table::regclass
                                                         AND adrelid=attrelid
                                                         AND pa.attnum=pad.adnum
-                          WHERE (adbin IS NULL)
+                                 -- pg_get_expr(adbin, adrelid) is equivalent to the adsrc column before pg12
+                                 -- this returns the sql code for the default value of a column.
+                                 -- for e.g if the default value is gen_random_uuid(), pg_get_expr(adbin, adrelid) returns gen_random_uuid().
+                                 -- if its a serial like it returns nextval('sequence_name') 
+                                 -- the bitemporal tables have a serial column suffixed with '_key'
+                                 -- which is a sequence, and they want to exclude it in the list of fields on a table
+                                 -- so they're filtering it out.
+                          WHERE ((pg_get_expr(adbin, adrelid) NOT LIKE 'nextval%'
+                                    and attname not like '%_key') 
+                                  OR adbin is NULL) 
                                 AND attname !='asserted'
                                 AND attname !='effective'
-                               -- AND attname !='row_created_at'
+                                AND attname !='row_created_at'
                                 and attname not like '%dropped%'
-                        ORDER BY pa.attnum));
+                        ORDER BY pa.attnum)
+      );
 END;                        
 $BODY$ LANGUAGE plpgsql
 $txt$;

--- a/sql/ll_bitemporal_update.sql
+++ b/sql/ll_bitemporal_update.sql
@@ -99,7 +99,7 @@ into v_keys;
                                   
 EXECUTE 
 --v_sql :=
-format($u$ UPDATE %s SET (%s) = ( %s ) 
+format($u$ UPDATE %s SET (%s) = (select %s ) 
                     WHERE ( %s )in ( %s ) $u$  
           , v_table
           , p_list_of_fields

--- a/sql/relationships.sql
+++ b/sql/relationships.sql
@@ -1,4 +1,4 @@
--- begin;
+ begin;
 create schema if not exists temporal_relationships;
 grant usage on schema temporal_relationships to public;
 set local search_path to temporal_relationships, public;
@@ -337,6 +337,6 @@ as $$
    select fst(a) >= snd(b) or fst(b) >= snd(a) ;
 $$
 SET search_path = 'temporal_relationships';
--- commit;
+ commit;
 
 -- vim: set filetype=pgsql expandtab tabstop=2 shiftwidth=2:


### PR DESCRIPTION
There are 3 main changes
1. I have uncommented the transactions, since they are needed when run in the pipeline.
2. I had removed a select in the update query, while this works for multi-column updates, it fails when only one column is updated. Not to mention the tests fail
3. modify the ll_bitemporal_list_of_fields function to only filter out the bitemporal serial key column. co-authored by @raghavio 



# Issue description

If a column has a default value, the bitemporal update doesn't update that column. Here is an example.

```sql
-- define an employees table
select * from bitemporal_internal.ll_create_bitemporal_table(
    'common',
    'employee',
  $$id uuid default gen_random_uuid(),
    name text,
    is_employee boolean default true$$,
  $$id$$
);

-- insert an employee
select bitemporal_internal.ll_bitemporal_insert('common.employee', $$id,name$$, $$'7db54823-3037-4aa0-8f84-d5df6a012e96','john doe'$$,
          temporal_relationships.timeperiod(now(), 'infinity'),
          temporal_relationships.timeperiod(now(), 'infinity'));

=> select * from common.employee;
 employee_key |                  id                  |   name   | is_employee |                 effective                  |                  asserted                  |        row_created_at
--------------+--------------------------------------+----------+-------------+--------------------------------------------+--------------------------------------------+-------------------------------
            4 | 7db54823-3037-4aa0-8f84-d5df6a012e96 | john doe | t           | ["2022-04-19 06:21:13.921072+00",infinity) | ["2022-04-19 06:21:13.921072+00",infinity) | 2022-04-19 06:21:13.921072+00

-- update the employee
=> select bitemporal_internal.ll_bitemporal_update('common','employee', $$id,name,is_employee$$, $$'7db54823-3037-4aa0-8f84-d5df6a012e96'::uuid,'Johnny Doe',false$$,
          $$id$$, $$'7db54823-3037-4aa0-8f84-d5df6a012e96'::uuid$$,
          temporal_relationships.timeperiod(now(), 'infinity'),
          temporal_relationships.timeperiod(now(), 'infinity'));

=> select * from employee;
 employee_key |                  id                  |    name    | is_employee |                             effective                             |                             asserted                              |        row_created_at
--------------+--------------------------------------+------------+-------------+-------------------------------------------------------------------+-------------------------------------------------------------------+-------------------------------
            8 | 7db54823-3037-4aa0-8f84-d5df6a012e96 | john doe   | t           | ["2022-04-19 08:02:31.384393+00",infinity)                        | ["2022-04-19 08:02:31.384393+00","2022-04-19 08:02:50.167008+00") | 2022-04-19 08:02:31.384393+00
           11 | 4227ae17-d672-4a61-a923-c9a398c2e66b | john doe   | t           | ["2022-04-19 08:02:31.384393+00","2022-04-19 08:02:50.167008+00") | ["2022-04-19 08:02:50.167008+00",infinity)                        | 2022-04-19 08:02:50.167008+00
           12 | 7db54823-3037-4aa0-8f84-d5df6a012e96 | Johnny Doe | f           | ["2022-04-19 08:02:50.167008+00",infinity)                        | ["2022-04-19 08:02:50.167008+00",infinity)                        | 2022-04-19 08:02:50.167008+00
(3 rows)
```

if you notice, the id for the middle row is different.

The bitemporal update function uses `ll_bitemporal_list_of_fields` to get the list of fields to update. 
see this https://github.com/teamohana/pg_bitemporal/blob/e0ed6924a8664e0ba78eb18e012d96a6b9ce1c42/sql/ll_bitemporal_update.sql#L31-L37
 
if we run the ll_bitemporal_list_of_fields for this table, we only get the `name` column.
It is filtering out ALL the default columns.
```sql
=> select bitemporal_internal.ll_bitemporal_list_of_fields('employee');
 ll_bitemporal_list_of_fields
------------------------------
 {name}
```

We (Raghav and I) believe the authors intention was to only filter out the bitemporal sequence key column and not other default columns