### PR TITLE
Fix for default values not being updated in update query

### DIFF
--- a/docs/pg_bitemporal_reference.md
+++ b/docs/pg_bitemporal_reference.md
@@ -198,22 +198,6 @@ select * from bitemporal_internal.ll_bitemporal_insert_select(
 
 Performs bitemporal update operation.
 
-This function has two signatures:
-
-```
-bitemporal_internal.ll_bitemporal_update(
-    p_table TEXT,
-    p_list_of_fields TEXT, -- fields to update
-    p_list_of_values TEXT, -- values to update with
-    p_search_fields TEXT, -- search fields
-    p_search_values TEXT, -- search values
-    p_effective temporal_relationships.timeperiod,
-    p_asserted temporal_relationships.timeperiod
-);
-
-```
-
-Returns: INTEGER
 
 ```
 bitemporal_internal.ll_bitemporal_update(
@@ -229,10 +213,6 @@ bitemporal_internal.ll_bitemporal_update(
 
 Returns: INTEGER
 
-_We strongly recommend to use the latter one, the first signature is
-non-compatiable with PG 10 and up, and is retained solely for the backward
-compatiability, will be eventually retired. In addition, the performance of
-the second version is much better._
 
 _bitemporal update has some significant limitations on it's usage. The most
 restrictive is that the search criteria are limited to the EQUAL to some
@@ -294,21 +274,6 @@ Performs bitemporal update, where both updated values and records to be updated 
 UPDATE T1 set (a1, a2) = (SELECT v1, v2 FROM T2 WHERE ) WHERE T1.a3 IN (SELECT )
 ```
 
-Same as simple update, this function also has two signatures:
-
-```
-bitemporal_internal.ll_bitemporal_update_select(
-    p_table TEXT,
-    p_list_of_fields TEXT,
-    p_values_selected_update TEXT,
-    p_search_fields TEXT, -- search fields
-    p_values_selected_search TEXT,
-    p_effective temporal_relationships.timeperiod,
-    p_asserted temporal_relationships.timeperiod
-);
-```
-
-Returns: INTEGER
 
 ```
 bitemporal_internal.ll_bitemporal_update_select(
@@ -324,8 +289,6 @@ bitemporal_internal.ll_bitemporal_update_select(
 ```
 
 Returns: INTEGER
-
-_Same warnings/recommendations are applicable for two versions of UPDATE_SELECT, as for simple UPDATE, however UPDATE_SELECT allows more complex search croteria._
 
 Input:
 

--- a/sql/ll_bitemporal_list_of_fields.sql
+++ b/sql/ll_bitemporal_list_of_fields.sql
@@ -33,15 +33,14 @@ $BODY$
 BEGIN
 RETURN ( array(SELECT attname
                           FROM (SELECT * FROM pg_attribute
-                                  WHERE attrelid=p_table::regclass AND attnum >0) pa
+                                  WHERE attrelid=p_table::regclass AND attnum >1) pa
                           LEFT OUTER JOIN pg_attrdef pad ON adrelid=p_table::regclass
                                                         AND adrelid=attrelid
                                                         AND pa.attnum=pad.adnum
-                          WHERE (adbin IS NULL)
-                                AND attname !='asserted'
+                          WHERE  attname !='asserted'
                                 AND attname !='effective'
-                               -- AND attname !='row_created_at'
-                                and attname not like '%dropped%'
+                                AND attname !='row_created_at'
+                                AND attname not like '%dropped%'
                         ORDER BY pa.attnum));
 END;                        
 $BODY$ LANGUAGE plpgsql


### PR DESCRIPTION
# Issue description

If a column has a default value, the bitemporal update doesn't update that column. Here is an example.

```sql
-- define an employees table
select * from bitemporal_internal.ll_create_bitemporal_table(
    'common',
    'employee',
  $$id uuid default gen_random_uuid(),
    name text,
    is_employee boolean default true$$,
  $$id$$
);

-- insert an employee
select bitemporal_internal.ll_bitemporal_insert('common.employee', $$id,name$$, $$'7db54823-3037-4aa0-8f84-d5df6a012e96','john doe'$$,
          temporal_relationships.timeperiod(now(), 'infinity'),
          temporal_relationships.timeperiod(now(), 'infinity'));

=> select * from common.employee;
 employee_key |                  id                  |   name   | is_employee |                 effective                  |                  asserted                  |        row_created_at
--------------+--------------------------------------+----------+-------------+--------------------------------------------+--------------------------------------------+-------------------------------
            4 | 7db54823-3037-4aa0-8f84-d5df6a012e96 | john doe | t           | ["2022-04-19 06:21:13.921072+00",infinity) | ["2022-04-19 06:21:13.921072+00",infinity) | 2022-04-19 06:21:13.921072+00

-- update the employee
=> select bitemporal_internal.ll_bitemporal_update('common','employee', $$id,name,is_employee$$, $$'7db54823-3037-4aa0-8f84-d5df6a012e96'::uuid,'Johnny Doe',false$$,
          $$id$$, $$'7db54823-3037-4aa0-8f84-d5df6a012e96'::uuid$$,
          temporal_relationships.timeperiod(now(), 'infinity'),
          temporal_relationships.timeperiod(now(), 'infinity'));

=> select * from employee;
 employee_key |                  id                  |    name    | is_employee |                             effective                             |                             asserted                              |        row_created_at
--------------+--------------------------------------+------------+-------------+-------------------------------------------------------------------+-------------------------------------------------------------------+-------------------------------
            8 | 7db54823-3037-4aa0-8f84-d5df6a012e96 | john doe   | t           | ["2022-04-19 08:02:31.384393+00",infinity)                        | ["2022-04-19 08:02:31.384393+00","2022-04-19 08:02:50.167008+00") | 2022-04-19 08:02:31.384393+00
           11 | 4227ae17-d672-4a61-a923-c9a398c2e66b | john doe   | t           | ["2022-04-19 08:02:31.384393+00","2022-04-19 08:02:50.167008+00") | ["2022-04-19 08:02:50.167008+00",infinity)                        | 2022-04-19 08:02:50.167008+00
           12 | 7db54823-3037-4aa0-8f84-d5df6a012e96 | Johnny Doe | f           | ["2022-04-19 08:02:50.167008+00",infinity)                        | ["2022-04-19 08:02:50.167008+00",infinity)                        | 2022-04-19 08:02:50.167008+00
(3 rows)
```

if you notice, the id for the middle row is different.

The bitemporal update function uses `ll_bitemporal_list_of_fields` to get the list of fields to update. 
see this https://github.com/teamohana/pg_bitemporal/blob/e0ed6924a8664e0ba78eb18e012d96a6b9ce1c42/sql/ll_bitemporal_update.sql#L31-L37
 
if we run the ll_bitemporal_list_of_fields for this table, we only get the `name` column.
It is filtering out ALL the default columns.
```sql
=> select bitemporal_internal.ll_bitemporal_list_of_fields('employee');
 ll_bitemporal_list_of_fields
------------------------------
 {name}
```

We (Raghav and I) believe the authors intention was to only filter out the bitemporal sequence key column and not other default columns